### PR TITLE
Update rcnn_features_pi.m

### DIFF
--- a/feature_extractor/rcnn_features_pi.m
+++ b/feature_extractor/rcnn_features_pi.m
@@ -24,7 +24,7 @@ fprintf('Computing features');
 tic;
 for j = 1:length(batches)
    fprintf('.');
-  B=[ batches(j),masked_batches(j)];
+  B=[ batches(j); masked_batches(j)];  % B=[ batches(j),masked_batches(j)];
   % forward propagate batch of region images 
   f = caffe('forward', B);
   f = f{1};


### PR DESCRIPTION
Candidate bounding boxes and candidate regions should be stacked as a vector before the forward feature calculation. Thus, line 27 needs a ';' instead of ','
This fixes MATLAB crash.
